### PR TITLE
Update Midnight infrastructure to Ledger v7 / Preprod

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ flowchart TB
 | agent | 8082 | (built locally) | Layer 2: Personal agent API |
 | zkp | 8084 | (built locally) | Layer 4: Zero-knowledge proof service |
 | midnight-proof-server | 6300 | `midnightntwrk/proof-server:7.0.0` | ZK proof generation (required for zkp) |
-| cardano-node | 3001 | `ghcr.io/intersectmbo/cardano-node:9.2.1` | Cardano preview testnet (optional) |
+| cardano-node | 3001 | `ghcr.io/intersectmbo/cardano-node:10.4.0` | Cardano preview testnet (optional) |
 | midnight-node | 9944 | `midnightntwrk/midnight-node:0.20.0` | Midnight node (optional) |
 | midnight-indexer | 8088 | `midnightntwrk/indexer-standalone:3.0.0` | Midnight indexer with bundled storage (optional) |
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ flowchart TB
 | midnight-proof-server | 6300 | `midnightntwrk/proof-server:7.0.0` | ZK proof generation (required for zkp) |
 | cardano-node | 3001 | `ghcr.io/intersectmbo/cardano-node:9.2.1` | Cardano preview testnet (optional) |
 | midnight-node | 9944 | `midnightntwrk/midnight-node:0.20.0` | Midnight node (optional) |
-| midnight-indexer | 8088 | `midnightntwrk/indexer-standalone:3.0.0` | Midnight indexer (optional) |
+| midnight-indexer | 8088 | `midnightntwrk/indexer-standalone:3.0.0` | Midnight indexer with bundled storage (optional) |
 
 ## Profiles
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo provides:
 
 - **Full-stack orchestration** - Run all PCI services together
 - **Development environment** - Hot reload, debugging, local testing
-- **Blockchain nodes** - Cardano and Midnight testnet configuration
+- **Blockchain nodes** - Cardano and Midnight network configuration (Ledger v7)
 - **Deployment scripts** - Contract deployment and setup utilities
 
 ## Quick Start
@@ -53,15 +53,15 @@ flowchart TB
 
 ## Services
 
-| Service | Port | Description |
-|---------|------|-------------|
-| context-store | 8081 | Layer 1: Encrypted vault API |
-| agent | 8082 | Layer 2: Personal agent API |
-| zkp | 8084 | Layer 4: Zero-knowledge proof service |
-| midnight-proof-server | 6300 | ZK proof generation (required for zkp) |
-| cardano-node | 3001 | Cardano preview testnet (optional) |
-| midnight-node | 9944 | Midnight standalone node (optional) |
-| midnight-indexer | 8088 | Midnight indexer (optional) |
+| Service | Port | Image | Description |
+|---------|------|-------|-------------|
+| context-store | 8081 | (built locally) | Layer 1: Encrypted vault API |
+| agent | 8082 | (built locally) | Layer 2: Personal agent API |
+| zkp | 8084 | (built locally) | Layer 4: Zero-knowledge proof service |
+| midnight-proof-server | 6300 | `midnightntwrk/proof-server:7.0.0` | ZK proof generation (required for zkp) |
+| cardano-node | 3001 | `ghcr.io/intersectmbo/cardano-node:9.2.1` | Cardano preview testnet (optional) |
+| midnight-node | 9944 | `midnightntwrk/midnight-node:0.20.0` | Midnight node (optional) |
+| midnight-indexer | 8088 | `midnightntwrk/indexer-standalone:3.0.0` | Midnight indexer (optional) |
 
 ## Profiles
 
@@ -95,8 +95,19 @@ cp configs/example.env .env
 
 Key settings:
 - `CARDANO_NETWORK` - preview (default), preprod, or mainnet
+- `MIDNIGHT_NETWORK` - preprod (default), preview, or mainnet
+- `MIDNIGHT_INDEXER_URL` - Midnight indexer GraphQL endpoint (v3 API)
+- `MIDNIGHT_NODE_URL` - Midnight node RPC endpoint
 - `MODEL_PATH` - Path to local LLM model file
 - `LOG_LEVEL` - debug, info, warn, error
+
+### Midnight Network Endpoints
+
+| Network | Indexer | Node | Faucet |
+|---------|--------|------|--------|
+| Preprod | `https://indexer.preprod.midnight.network/api/v3/graphql` | `https://rpc.preprod.midnight.network` | `https://faucet.preprod.midnight.network` |
+| Preview | `https://indexer.preview.midnight.network/api/v3/graphql` | `https://rpc.preview.midnight.network` | - |
+| Local | `http://127.0.0.1:8088/api/v3/graphql` | `http://127.0.0.1:9944` | - |
 
 ## Scripts
 

--- a/configs/example.env
+++ b/configs/example.env
@@ -48,12 +48,19 @@ MIDNIGHT_NETWORK=preprod
 #   MIDNIGHT_PROOF_SERVER_URL=http://127.0.0.1:6300
 
 # Midnight indexer network ID (used by standalone indexer)
+# "undeployed" is correct for local dev (CFG_PRESET=dev).
+# For preprod: use the network ID shown at https://docs.midnight.network
+# For preview: use the preview network ID from the same docs.
 MIDNIGHT_NETWORK_ID=undeployed
 
-# Midnight indexer passwords (used by standalone indexer)
-INDEXER_STORAGE_PASSWORD=indexer
-INDEXER_PUBSUB_PASSWORD=indexer
-INDEXER_LEDGER_PASSWORD=indexer
+# WARNING: Dev-only defaults below. MUST change before any non-local deployment.
+# Midnight indexer passwords (used by standalone indexer's embedded storage)
+INDEXER_STORAGE_PASSWORD=CHANGE_ME_indexer_storage
+INDEXER_PUBSUB_PASSWORD=CHANGE_ME_indexer_pubsub
+INDEXER_LEDGER_PASSWORD=CHANGE_ME_indexer_ledger
+
+# Proof server flags (e.g. "-v" for verbose logging)
+MIDNIGHT_PROOF_SERVER_FLAGS=-v
 
 # ===========================================
 # Service Ports (change if conflicts)

--- a/configs/example.env
+++ b/configs/example.env
@@ -21,8 +21,39 @@ MODEL_FILE=phi-3-mini-q4.gguf
 # Cardano network: preview, preprod, mainnet
 CARDANO_NETWORK=preview
 
-# Midnight network: testnet, mainnet
-MIDNIGHT_NETWORK=testnet
+# Midnight network: preprod, preview, mainnet
+MIDNIGHT_NETWORK=preprod
+
+# ===========================================
+# Midnight Network Endpoints
+# ===========================================
+# For local development (with-midnight profile), leave these as defaults.
+# For remote networks, set to the appropriate endpoints below.
+#
+# Preprod endpoints:
+#   MIDNIGHT_INDEXER_URL=https://indexer.preprod.midnight.network/api/v3/graphql
+#   MIDNIGHT_INDEXER_WS_URL=wss://indexer.preprod.midnight.network/api/v3/graphql/ws
+#   MIDNIGHT_NODE_URL=https://rpc.preprod.midnight.network
+#   MIDNIGHT_FAUCET_URL=https://faucet.preprod.midnight.network
+#
+# Preview endpoints:
+#   MIDNIGHT_INDEXER_URL=https://indexer.preview.midnight.network/api/v3/graphql
+#   MIDNIGHT_INDEXER_WS_URL=wss://indexer.preview.midnight.network/api/v3/graphql/ws
+#   MIDNIGHT_NODE_URL=https://rpc.preview.midnight.network
+#
+# Local endpoints (with-midnight profile):
+#   MIDNIGHT_INDEXER_URL=http://127.0.0.1:8088/api/v3/graphql
+#   MIDNIGHT_INDEXER_WS_URL=ws://127.0.0.1:8088/api/v3/graphql/ws
+#   MIDNIGHT_NODE_URL=http://127.0.0.1:9944
+#   MIDNIGHT_PROOF_SERVER_URL=http://127.0.0.1:6300
+
+# Midnight indexer network ID (used by standalone indexer)
+MIDNIGHT_NETWORK_ID=undeployed
+
+# Midnight indexer passwords (used by standalone indexer)
+INDEXER_STORAGE_PASSWORD=indexer
+INDEXER_PUBSUB_PASSWORD=indexer
+INDEXER_LEDGER_PASSWORD=indexer
 
 # ===========================================
 # Service Ports (change if conflicts)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     image: midnightntwrk/proof-server:7.0.0
     ports:
       - "6300:6300"
-    command: ["midnight-proof-server", "-v"]
+    command: ["midnight-proof-server", "${MIDNIGHT_PROOF_SERVER_FLAGS:-}"]
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:6300/health"]
       interval: 30s
@@ -138,6 +138,8 @@ services:
     networks:
       - pci-network
 
+  # indexer-standalone bundles its own storage (no external DB required).
+  # The INDEXER_*_PASSWORD vars configure its embedded storage components.
   midnight-indexer:
     image: midnightntwrk/indexer-standalone:3.0.0
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,9 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8084:8084"
+    # NOTE: URL defaults point to local Docker services (require --profile with-midnight
+    # or --profile standalone). For remote networks, override these in .env — see
+    # configs/example.env for preprod/preview endpoint references.
     environment:
       - PORT=8084
       - MIDNIGHT_NETWORK=${MIDNIGHT_NETWORK:-preprod}
@@ -79,7 +82,7 @@ services:
   # Connects to preview testnet
   # ===========================================
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.2.1
+    image: ghcr.io/intersectmbo/cardano-node:10.4.0
     ports:
       - "3001:3001"
     volumes:
@@ -109,7 +112,7 @@ services:
     image: midnightntwrk/proof-server:7.0.0
     ports:
       - "6300:6300"
-    command: ["midnight-proof-server", "${MIDNIGHT_PROOF_SERVER_FLAGS:-}"]
+    command: sh -c "midnight-proof-server ${MIDNIGHT_PROOF_SERVER_FLAGS:-}"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:6300/health"]
       interval: 30s
@@ -147,9 +150,9 @@ services:
     environment:
       - CFG_PRESET=${MIDNIGHT_CFG_PRESET:-dev}
       - APP__APPLICATION__NETWORK_ID=${MIDNIGHT_NETWORK_ID:-undeployed}
-      - APP__INFRA__STORAGE__PASSWORD=${INDEXER_STORAGE_PASSWORD:-indexer}
-      - APP__INFRA__PUB_SUB__PASSWORD=${INDEXER_PUBSUB_PASSWORD:-indexer}
-      - APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD=${INDEXER_LEDGER_PASSWORD:-indexer}
+      - APP__INFRA__STORAGE__PASSWORD=${INDEXER_STORAGE_PASSWORD}
+      - APP__INFRA__PUB_SUB__PASSWORD=${INDEXER_PUBSUB_PASSWORD}
+      - APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD=${INDEXER_LEDGER_PASSWORD}
     depends_on:
       - midnight-node
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,11 @@ services:
       - "8084:8084"
     environment:
       - PORT=8084
-      - MIDNIGHT_NETWORK=${MIDNIGHT_NETWORK:-testnet}
+      - MIDNIGHT_NETWORK=${MIDNIGHT_NETWORK:-preprod}
+      - MIDNIGHT_INDEXER_URL=${MIDNIGHT_INDEXER_URL:-http://midnight-indexer:8088/api/v3/graphql}
+      - MIDNIGHT_INDEXER_WS_URL=${MIDNIGHT_INDEXER_WS_URL:-ws://midnight-indexer:8088/api/v3/graphql/ws}
+      - MIDNIGHT_NODE_URL=${MIDNIGHT_NODE_URL:-http://midnight-node:9944}
+      - MIDNIGHT_PROOF_SERVER_URL=${MIDNIGHT_PROOF_SERVER_URL:-http://midnight-proof-server:6300}
       - LOG_LEVEL=${LOG_LEVEL:-info}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8084/health"]
@@ -99,14 +103,13 @@ services:
   # ===========================================
   # Midnight Proof Server
   # Required for ZK proof generation
+  # Pre-baked ZK params, Ledger v7
   # ===========================================
   midnight-proof-server:
-    # Pin to 4.0.0 - newer versions (6.x) reported not working
-    # See: https://forum.midnight.network/t/please-use-proof-server-version-4-0-0/727
-    image: midnightnetwork/proof-server:4.0.0
+    image: midnightntwrk/proof-server:7.0.0
     ports:
       - "6300:6300"
-    command: "'midnight-proof-server --network ${MIDNIGHT_NETWORK:-testnet}'"
+    command: ["midnight-proof-server", "-v"]
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:6300/health"]
       interval: 30s
@@ -118,9 +121,10 @@ services:
   # ===========================================
   # Midnight Standalone (for local testing)
   # Runs node + indexer + proof-server isolated
+  # Ledger v7 images from midnightntwrk registry
   # ===========================================
   midnight-node:
-    image: midnightnetwork/midnight-node:latest
+    image: midnightntwrk/midnight-node:0.20.0
     ports:
       - "9944:9944"
     volumes:
@@ -135,11 +139,15 @@ services:
       - pci-network
 
   midnight-indexer:
-    image: midnightnetwork/indexer:latest
+    image: midnightntwrk/indexer-standalone:3.0.0
     ports:
       - "8088:8088"
     environment:
       - CFG_PRESET=${MIDNIGHT_CFG_PRESET:-dev}
+      - APP__APPLICATION__NETWORK_ID=${MIDNIGHT_NETWORK_ID:-undeployed}
+      - APP__INFRA__STORAGE__PASSWORD=${INDEXER_STORAGE_PASSWORD:-indexer}
+      - APP__INFRA__PUB_SUB__PASSWORD=${INDEXER_PUBSUB_PASSWORD:-indexer}
+      - APP__INFRA__LEDGER_STATE_STORAGE__PASSWORD=${INDEXER_LEDGER_PASSWORD:-indexer}
     depends_on:
       - midnight-node
     profiles:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,6 +6,20 @@ PROFILE=""
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --help|-h)
+            echo "Usage: start.sh [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --with-cardano    Start with Cardano preview testnet node"
+            echo "  --with-midnight   Start with Midnight local node + indexer"
+            echo "  --with-nodes      Start with all blockchain nodes"
+            echo "  --standalone      Isolated Midnight environment (node + indexer)"
+            echo "  --dev             Development mode with hot reload"
+            echo "  -h, --help        Show this help message"
+            echo ""
+            echo "Environment: copy configs/example.env to .env and customize."
+            exit 0
+            ;;
         --with-cardano)
             PROFILE="--profile with-cardano"
             shift

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -18,6 +18,10 @@ while [[ $# -gt 0 ]]; do
             PROFILE="--profile with-nodes"
             shift
             ;;
+        --standalone)
+            PROFILE="--profile standalone"
+            shift
+            ;;
         --dev)
             DEV="-f docker-compose.yml -f docker-compose.dev.yml"
             shift

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -21,7 +21,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         --with-cardano)
-            PROFILE="--profile with-cardano"
+            PROFILE="--profile cardano-testnet"
             shift
             ;;
         --with-midnight)


### PR DESCRIPTION
## Summary

- Migrates all Midnight Docker images to the current Preprod network (Ledger v7)
- Updates Docker registry from `midnightnetwork/` to `midnightntwrk/`
- Wires Midnight network endpoints through the ZKP service container
- Adds comprehensive endpoint reference for preprod, preview, and local networks

## Changes

### Docker Images
| Service | Before | After |
|---------|--------|-------|
| Proof Server | `midnightnetwork/proof-server:4.0.0` | `midnightntwrk/proof-server:7.0.0` |
| Node | `midnightnetwork/midnight-node:latest` | `midnightntwrk/midnight-node:0.20.0` |
| Indexer | `midnightnetwork/indexer:latest` | `midnightntwrk/indexer-standalone:3.0.0` |

### Configuration
- Proof server no longer requires `--network` flag (uses `-v` for verbose)
- Indexer standalone requires new env vars: `NETWORK_ID`, storage/pubsub/ledger passwords
- ZKP service now receives `MIDNIGHT_INDEXER_URL`, `MIDNIGHT_NODE_URL`, `MIDNIGHT_PROOF_SERVER_URL`
- Default network changed from `testnet` to `preprod`
- API paths updated from v1 to v3

### Documentation
- README updated with current image versions and endpoint table
- example.env has full endpoint reference with preprod/preview/local options

## Test plan

- [ ] `docker compose config` validates compose file
- [ ] `docker compose --profile with-midnight up` pulls correct images
- [ ] ZKP service receives endpoint env vars correctly
- [ ] Proof server starts without `--network` flag

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Midnight Network Endpoints for Preprod, Preview and Local environments and expanded configuration guidance, including example endpoint URLs and environment variable usage.

* **New Features**
  * Added a standalone startup profile/flag and updated guidance for Midnight environment variables (network, indexer and node URLs).
  * Services table now shows an Image column with image references for each service.

* **Chores**
  * Updated Midnight-related service images to newer stable releases and expanded indexer credentials/configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->